### PR TITLE
Add support for Demagnetize mod and Conveyors

### DIFF
--- a/java/werty/simplemagnet/Items/ItemMagnet.java
+++ b/java/werty/simplemagnet/Items/ItemMagnet.java
@@ -96,7 +96,7 @@ public class ItemMagnet extends Item
 				{
 					if(!player.isSneaking() && cooldown == 0)
 					{
-						if(!isBlackListed(e.getEntityItem()))
+						if(!e.getEntityData().getBoolean("PreventRemoteMovement") && !isBlackListed(e.getEntityItem()))
 						{
 							isPulling = true;
 							


### PR DESCRIPTION
Immersive Engineering's conveyors (and [my Demagnetize mod](https://minecraft.curseforge.com/projects/demagnetize)) add the PreventRemoteMovement NBT tag to the item. This prevents them from being picked up by magnets.